### PR TITLE
Scale bar modules and adjust height

### DIFF
--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -30,7 +30,11 @@ Variants {
                 right: true
             }
             
-            implicitHeight: 45
+            // Height of the panel
+            implicitHeight: 50
+
+            // Global scale used by widgets inside the bar
+            readonly property real scaleFactor: implicitHeight / 45
             margins {
                 top: 0
                 left: 0
@@ -52,9 +56,9 @@ Variants {
                     anchors {
                         left: parent.left
                         verticalCenter: parent.verticalCenter
-                        leftMargin: 16
+                        leftMargin: 16 * panel.scaleFactor
                     }
-                    spacing: 8
+                    spacing: 8 * panel.scaleFactor
                     
                     // Real Hyprland workspace data
                     Repeater {
@@ -64,12 +68,12 @@ Variants {
                             // mostra solo i workspace il cui monitor corrisponde a questo screen
                             visible: modelData.monitor.id === Hyprland.monitorFor(screen).id
 
-                            width: 30
-                            height: 24
-                            radius: 8
+                            width: 30 * panel.scaleFactor
+                            height: 24 * panel.scaleFactor
+                            radius: 8 * panel.scaleFactor
                             color: modelData.active ? "#4a9eff" : "#333333"
                             border.color: "#555555"
-                            border.width: 1
+                            border.width: 1 * panel.scaleFactor
 
                             MouseArea {
                                 anchors.fill: parent
@@ -80,7 +84,7 @@ Variants {
                                 text: modelData.id
                                 anchors.centerIn: parent
                                 color: modelData.active ? "#ffffff" : "#cccccc"
-                                font.pixelSize: 12
+                                font.pixelSize: 12 * panel.scaleFactor
                                 font.family: "CaskaydiaMono Nerd Font"
                             }
                         }
@@ -91,7 +95,7 @@ Variants {
                         visible: Hyprland.workspaces.length === 0
                         text: "No workspaces"
                         color: "#ffffff"
-                        font.pixelSize: 12
+                        font.pixelSize: 12 * panel.scaleFactor
                     }
                 }
 
@@ -99,6 +103,7 @@ Variants {
                 SystemTray {
                     id: systemTrayWidget
                     bar: panel  // Pass the panel window reference
+                    scaleFactor: panel.scaleFactor
                     anchors {
                         right: logoutButton.left
                         verticalCenter: parent.verticalCenter
@@ -109,16 +114,16 @@ Variants {
                 // Button to trigger wlogout between tray and clock
                 Rectangle {
                     id: logoutButton
-                    width: 30
-                    height: 24
-                    radius: 10
+                    width: 30 * panel.scaleFactor
+                    height: 24 * panel.scaleFactor
+                    radius: 10 * panel.scaleFactor
                     color: "#333333"
                     border.color: "#555555"
-                    border.width: 1
+                    border.width: 1 * panel.scaleFactor
                     anchors {
                         right: timeDisplay.left
                         verticalCenter: parent.verticalCenter
-                        rightMargin: 16
+                        rightMargin: 16 * panel.scaleFactor
                     }
 
                     MouseArea {
@@ -130,7 +135,7 @@ Variants {
                         anchors.centerIn: parent
                         text: "" // power icon
                         color: "#cccccc"
-                        font.pixelSize: 12
+                        font.pixelSize: 12 * panel.scaleFactor
                         font.family: "CaskaydiaMono Nerd Font"
                     }
                 }
@@ -141,14 +146,14 @@ Variants {
                     anchors {
                         right: parent.right
                         verticalCenter: parent.verticalCenter
-                        rightMargin: 16
+                        rightMargin: 16 * panel.scaleFactor
                     }
                     
                     property string currentTime: ""
                     
                     text: currentTime
                     color: "#ffffff"
-                    font.pixelSize: 14
+                    font.pixelSize: 14 * panel.scaleFactor
                     font.family: "CaskaydiaMono Nerd Font"
                     
                     // Update time every second

--- a/modules/bar/widgets/SystemTray.qml
+++ b/modules/bar/widgets/SystemTray.qml
@@ -8,6 +8,8 @@ Item {
     
     // Required property for the bar window reference
     required property var bar
+    // Scale factor to size the tray items
+    property real scaleFactor: 1.0
     
     // Dark theme colors matching the bar theme
     readonly property color surfaceVariant: "#333333"
@@ -15,9 +17,13 @@ Item {
     readonly property color textPrimary: "#ffffff"
     readonly property color backgroundPrimary: "#1a1a1a"
     
-    readonly property int iconSize: 22
-    readonly property int iconSpacing: 8
-    readonly property int iconPadding: 4
+    readonly property int baseIconSize: 22
+    readonly property int baseIconSpacing: 8
+    readonly property int baseIconPadding: 4
+
+    readonly property int iconSize: baseIconSize * scaleFactor
+    readonly property int iconSpacing: baseIconSpacing * scaleFactor
+    readonly property int iconPadding: baseIconPadding * scaleFactor
     
     // Calculate width based on number of tray items
     width: Math.max(0, trayRow.children.length * (iconSize + iconSpacing) - iconSpacing)
@@ -102,7 +108,7 @@ Item {
                         anchors.centerIn: parent
                         text: trayItem.title ? trayItem.title.charAt(0).toUpperCase() : "?"
                         color: textPrimary
-                        font.pixelSize: 12
+                        font.pixelSize: 12 * scaleFactor
                         font.bold: true
                         visible: parent.status === Image.Error || parent.status === Image.Null
                     }
@@ -114,10 +120,10 @@ Item {
                     visible: trayMouseArea.containsMouse && trayItem.title && trayItem.title.length > 0
                     color: backgroundPrimary
                     border.color: surfaceVariant
-                    border.width: 1
+                    border.width: 1 * scaleFactor
                     radius: 6
-                    width: tooltipText.width + 16
-                    height: tooltipText.height + 12
+                    width: tooltipText.width + 16 * scaleFactor
+                    height: tooltipText.height + 12 * scaleFactor
                     
                     // Position tooltip above the icon
                     anchors.bottom: parent.top
@@ -129,7 +135,7 @@ Item {
                         anchors.centerIn: parent
                         text: trayItem.title || ""
                         color: textPrimary
-                        font.pixelSize: 11
+                        font.pixelSize: 11 * scaleFactor
                     }
                     
                     // Fade in/out animation
@@ -151,7 +157,7 @@ Item {
         visible: SystemTray.items.length === 0
         text: "No tray items"
         color: surfaceVariant
-        font.pixelSize: 10
+        font.pixelSize: 10 * scaleFactor
         font.family: "CaskaydiaMono Nerd Font"
         opacity: 0.7
     }


### PR DESCRIPTION
## Summary
- raise bar implicit height to 50
- introduce `scaleFactor` for scaling widgets
- enlarge workspace, system tray and other modules using the factor

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688d38039840832c94c36c6ec8e3c5e4