### PR TITLE
Add system tray tooltip

### DIFF
--- a/modules/bar/widgets/SystemTray.qml
+++ b/modules/bar/widgets/SystemTray.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Controls
 import Quickshell
 import Quickshell.Services.SystemTray
 
@@ -24,11 +25,48 @@ Item {
     readonly property int iconSize: baseIconSize * scaleFactor
     readonly property int iconSpacing: baseIconSpacing * scaleFactor
     readonly property int iconPadding: baseIconPadding * scaleFactor
-    
+
     // Calculate width based on number of tray items
     width: Math.max(0, trayRow.children.length * (iconSize + iconSpacing) - iconSpacing)
     height: iconSize + iconPadding * 2
-    
+
+    // Hover handler covering the entire system tray area
+    HoverHandler {
+        id: trayHover
+    }
+
+    // Tooltip shown when hovering over the tray area
+    Rectangle {
+        id: trayTooltip
+        visible: trayHover.hovered
+        color: backgroundPrimary
+        border.color: surfaceVariant
+        border.width: 1 * scaleFactor
+        radius: 6
+        width: trayTooltipText.width + 16 * scaleFactor
+        height: trayTooltipText.height + 12 * scaleFactor
+        anchors.bottom: parent.top
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.bottomMargin: 8
+        z: 100
+
+        Text {
+            id: trayTooltipText
+            anchors.centerIn: parent
+            text: qsTr("System Tray")
+            color: textPrimary
+            font.pixelSize: 11 * scaleFactor
+        }
+
+        opacity: trayHover.hovered ? 1.0 : 0.0
+        Behavior on opacity {
+            NumberAnimation {
+                duration: 200
+                easing.type: Easing.OutCubic
+            }
+        }
+    }
+
     // Row to hold all system tray icons
     Row {
         id: trayRow


### PR DESCRIPTION
## Summary
- import QtQuick.Controls for tooltip support
- show a tooltip for the entire system tray when hovered

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688d3c386c04832c90c5a97b7af8f9e9