### PR TITLE
Adjust tooltip position in system tray

### DIFF
--- a/modules/bar/widgets/SystemTray.qml
+++ b/modules/bar/widgets/SystemTray.qml
@@ -125,10 +125,10 @@ Item {
                     width: tooltipText.width + 16 * scaleFactor
                     height: tooltipText.height + 12 * scaleFactor
                     
-                    // Position tooltip above the icon
-                    anchors.bottom: parent.top
+                    // Position tooltip below the icon
+                    anchors.top: parent.bottom
                     anchors.horizontalCenter: parent.horizontalCenter
-                    anchors.bottomMargin: 8
+                    anchors.topMargin: 8
                     
                     Text {
                         id: tooltipText


### PR DESCRIPTION
## Summary
- show system tray tooltips below each icon

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688d3dba4f00832ca33355ded92a0484