### PR TITLE
Fix system tray tooltip placement

### DIFF
--- a/modules/bar/widgets/SystemTray.qml
+++ b/modules/bar/widgets/SystemTray.qml
@@ -115,11 +115,22 @@ Item {
                     }
                 }
 
-                // ToolTip attachable
+                // ToolTip shown when hovering a tray icon
                 ToolTip.visible: trayMouseArea.containsMouse && trayItem.title.length > 0
                 ToolTip.text: trayItem.title
-                ToolTip.delay: 200   // ms di ritardo prima di mostrare
-                Rectangle {
+                ToolTip.delay: 200   // delay before showing the tooltip
+
+                // Place the tooltip below the tray icon and draw it outside
+                // of the bar so it doesn't get clipped
+                ToolTip.parent: Overlay.overlay
+                ToolTip.x: trayMouseArea.mapToItem(Overlay.overlay,
+                                                 (trayMouseArea.width - ToolTip.implicitWidth) / 2,
+                                                 0).x
+                ToolTip.y: trayMouseArea.mapToItem(Overlay.overlay,
+                                                 0,
+                                                 trayMouseArea.height + 4).y
+
+                ToolTip.background: Rectangle {
                     color: backgroundPrimary
                     border.color: surfaceVariant
                     border.width: 1 * scaleFactor


### PR DESCRIPTION
## Summary
- allow system tray tooltip to render outside the bar window
- anchor tooltip below tray icons to avoid clipping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d47a95974832c9f996003da66d43f