### PR TITLE
Make system tray responsive and fix menu anchor

### DIFF
--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -122,8 +122,8 @@ Variants {
 
                     Rectangle{
                         id: trayButton
-                        width: 200 * panel.scaleFactor
-                        height: 30 * panel.scaleFactor
+                        width: systemTrayWidget.width
+                        height: systemTrayWidget.height
                         radius: 10 * panel.scaleFactor
                         color: "#333333"
                         border.color: "#555555"
@@ -137,11 +137,7 @@ Variants {
                             id: systemTrayWidget
                             bar: panel  // Pass the panel window reference
                             scaleFactor: panel.scaleFactor
-                            anchors {
-                                right: networkButton.left
-                                verticalCenter: parent.verticalCenter
-                                rightMargin: 0
-                            }
+                            anchors.centerIn: parent
                         }
                     }
 

--- a/modules/bar/widgets/SystemTray.qml
+++ b/modules/bar/widgets/SystemTray.qml
@@ -27,14 +27,20 @@ Item {
     readonly property int iconSpacing: baseIconSpacing * scaleFactor
     readonly property int iconPadding: baseIconPadding * scaleFactor
 
-    // Calculate width based on number of tray items
-    width: Math.max(0, trayRow.children.length * (iconSize + iconSpacing) - iconSpacing)
+    // Calculate width based on number of tray items including padding
+    width: SystemTray.items.length > 0
+           ? SystemTray.items.length * (iconSize + iconSpacing) - iconSpacing + iconPadding * 2
+           : 0
     height: iconSize + iconPadding * 2
 
     // Row to hold all system tray icons
     Row {
         id: trayRow
-        anchors.centerIn: parent
+        anchors {
+            left: parent.left
+            verticalCenter: parent.verticalCenter
+            leftMargin: iconPadding
+        }
         spacing: iconSpacing
 
         Repeater {
@@ -67,14 +73,17 @@ Item {
                     trayItem.scroll(wheel.angleDelta.x, wheel.angleDelta.y)
                 }
 
+                // Global position for the context menu anchor
+                property point globalPos: mapToItem(systemTrayWidget.bar.contentItem, 0, 0)
+
                 // Context menu anchor
                 QsMenuAnchor {
                     id: menuAnchor
 
                     menu: trayItem.menu
                     anchor.window: systemTrayWidget.bar
-                    anchor.rect.x: trayMouseArea.x + systemTrayWidget.x
-                    anchor.rect.y: trayMouseArea.y + systemTrayWidget.y
+                    anchor.rect.x: trayMouseArea.globalPos.x
+                    anchor.rect.y: trayMouseArea.globalPos.y
                     anchor.rect.width: trayMouseArea.width
                     anchor.rect.height: trayMouseArea.height
                     anchor.edges: Edges.Bottom


### PR DESCRIPTION
## Summary
- Resize tray container based on number of icons
- Anchor tray context menus to correct screen position

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e0b2b11ec832cb99b461372bfd2b2