### PR TITLE
feat: add dynamic volume icon

### DIFF
--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Shapes
 import Quickshell
 import Quickshell.Hyprland
+import Quickshell.Services.Pipewire
 import Qt.labs.platform 1.1
 import "widgets/"
 import org.kde.layershell 1.0
@@ -171,13 +172,28 @@ Variants {
 
                         property bool isEthernet: true
                         property string networkIcon: isEthernet ? "" : ""
+                        property string volumeIcon: ""
+
+                        function updateVolumeIcon() {
+                            var sink = Pipewire.defaultAudioSink
+                            var vol = sink.volume
+                            if (sink.description && sink.description.toLowerCase().indexOf("headset") !== -1) {
+                                volumeIcon = ""
+                            } else if (sink.mute || vol <= 0.0) {
+                                volumeIcon = ""
+                            } else if (vol <= 0.5) {
+                                volumeIcon = ""
+                            } else {
+                                volumeIcon = ""
+                            }
+                        }
 
                         Row {
                             anchors.centerIn: parent
                             spacing: 4 * panel.scaleFactor
 
                                 Text {
-                                    text: rightsidebarButton.networkIcon + "  "
+                                    text: rightsidebarButton.networkIcon + "  " + rightsidebarButton.volumeIcon
                                     color: moduleFontColor
                                     font.pixelSize: 15 * panel.scaleFactor
                                     font.family: "CaskaydiaMono Nerd Font"
@@ -190,8 +206,6 @@ Variants {
                             onClicked: connectionWindow.visible = !connectionWindow.visible
                         }
 
-
-
                         Timer {
                             interval: 10000
                             running: true
@@ -199,7 +213,13 @@ Variants {
                             onTriggered: nmcliProcess.start()
                         }
 
-                        Component.onCompleted: nmcliProcess.start()
+                        Connections {
+                            target: Pipewire.defaultAudioSink
+                            function onVolumeChanged() { rightsidebarButton.updateVolumeIcon() }
+                            function onMuteChanged() { rightsidebarButton.updateVolumeIcon() }
+                        }
+
+                        Component.onCompleted: { nmcliProcess.start(); updateVolumeIcon() }
                     }
 
                     // Button to trigger wlogout between tray and clock


### PR DESCRIPTION
## Summary
- show network and volume icons together
- swap volume icon based on current sink volume and mute status

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e1fbc2688832c9cfa25ffa617e000