### PR TITLE
Improve ConnectionSettings overlay styling

### DIFF
--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -32,16 +32,21 @@ Variants {
             PanelWindow {
                 id: connectionWindow
                 screen: delegateRoot.modelData
+                layer: LayerShell.Layer.Overlay
                 anchors {
                     top: true
-                    bottom: true
                     right: true
                 }
+                margins {
+                    right: 16
+                }
                 width: 300
+                height: connectionContent.implicitHeight
                 visible: false
-                color: moduleColor
+                color: "transparent"
 
                 ConnectionSettings {
+                    id: connectionContent
                     anchors.fill: parent
                 }
             }

--- a/modules/bar/widgets/ConnectionSettings.qml
+++ b/modules/bar/widgets/ConnectionSettings.qml
@@ -3,14 +3,18 @@ import QtQuick.Controls
 
 Rectangle {
     id: root
+    property int margin: 16
     anchors.fill: parent
     color: "#222222"
     radius: 8
+    border.color: "#555555"
+    border.width: 1
+    implicitHeight: content.implicitHeight + margin * 2
 
     Column {
         id: content
         anchors.fill: parent
-        anchors.margins: 16
+        anchors.margins: root.margin
         spacing: 24
 
         // Uptime bar


### PR DESCRIPTION
## Summary
- Show the ConnectionSettings panel as an overlay with right margin and dynamic height
- Add bordered, rounded styling and content-based height to the ConnectionSettings component

## Testing
- `qmlformat -n modules/bar/Bar.qml modules/bar/widgets/ConnectionSettings.qml` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e59957a1c832c9eab8bba322d52a6