### PR TITLE
feat: layout and enable volume brightness sliders

### DIFF
--- a/modules/bar/widgets/ConnectionSettings.qml
+++ b/modules/bar/widgets/ConnectionSettings.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 import Quickshell.Services.Pipewire
 import Quickshell.Hyprland
 
@@ -111,7 +112,7 @@ Rectangle {
         }
 
         // Volume slider
-        Row {
+        RowLayout {
             id: volumeRow
             width: parent.width
             spacing: 8
@@ -122,13 +123,13 @@ Rectangle {
                 color: "#ffffff"
                 font.pixelSize: 16
                 font.family: "CaskaydiaMono Nerd Font"
-                anchors.verticalCenter: parent.verticalCenter
+                Layout.alignment: Qt.AlignVCenter
             }
 
             Slider {
                 id: volumeSlider
-                anchors.verticalCenter: parent.verticalCenter
-                width: volumeRow.width - volumeIcon.width - volumeRow.spacing
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignVCenter
                 from: 0
                 to: 100
                 value: 50
@@ -161,7 +162,7 @@ Rectangle {
         }
 
         // Brightness slider
-        Row {
+        RowLayout {
             id: brightnessRow
             width: parent.width
             spacing: 8
@@ -172,13 +173,13 @@ Rectangle {
                 color: "#ffffff"
                 font.pixelSize: 16
                 font.family: "CaskaydiaMono Nerd Font"
-                anchors.verticalCenter: parent.verticalCenter
+                Layout.alignment: Qt.AlignVCenter
             }
 
             Slider {
                 id: brightnessSlider
-                anchors.verticalCenter: parent.verticalCenter
-                width: brightnessRow.width - brightnessIcon.width - brightnessRow.spacing
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignVCenter
                 from: 0
                 to: 100
                 value: 80


### PR DESCRIPTION
## Summary
- use RowLayout for volume and brightness controls
- ensure icons stay on the left and sliders fill remaining width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e5e00e554832ca7cd5b0d030d44c0