### PR TITLE
Add mouse wheel control for volume and brightness sliders

### DIFF
--- a/modules/bar/widgets/ConnectionSettings.qml
+++ b/modules/bar/widgets/ConnectionSettings.qml
@@ -158,6 +158,14 @@ Rectangle {
                     color: "#ffffff"
                     border.color: "#888888"
                 }
+                WheelHandler {
+                    onWheel: {
+                        const step = 5;
+                        volumeSlider.value = Math.min(volumeSlider.to,
+                                                     Math.max(volumeSlider.from,
+                                                              volumeSlider.value + step * wheel.angleDelta.y / 120))
+                    }
+                }
             }
         }
 
@@ -206,6 +214,14 @@ Rectangle {
                     radius: 8
                     color: "#ffffff"
                     border.color: "#888888"
+                }
+                WheelHandler {
+                    onWheel: {
+                        const step = 5;
+                        brightnessSlider.value = Math.min(brightnessSlider.to,
+                                                         Math.max(brightnessSlider.from,
+                                                                  brightnessSlider.value + step * wheel.angleDelta.y / 120))
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- enable volume slider to respond to mouse wheel
- allow brightness slider to change with mouse wheel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e60b03dd8832c8e156f0ca0db7ad8