### PR TITLE
Close ConnectionSettings on escape or focus loss and show real uptime

### DIFF
--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -43,6 +43,8 @@ Variants {
                 height: connectionContent.implicitHeight
                 visible: false
                 color: "transparent"
+                onActiveChanged: if (!active) visible = false
+                onVisibleChanged: if (visible) connectionContent.forceActiveFocus()
 
                 ConnectionSettings {
                     id: connectionContent

--- a/modules/bar/widgets/ConnectionSettings.qml
+++ b/modules/bar/widgets/ConnectionSettings.qml
@@ -13,6 +13,13 @@ Rectangle {
     border.color: "#555555"
     border.width: 1
     implicitHeight: content.implicitHeight + margin * 2
+    focus: true
+
+    Shortcut {
+        sequence: "Escape"
+        context: Qt.WindowShortcut
+        onActivated: root.window.visible = false
+    }
 
     Column {
         id: content
@@ -33,7 +40,8 @@ Rectangle {
             }
 
             Text {
-                text: "Uptime: 7h, 48m"
+                id: uptimeText
+                text: "Uptime: 0h, 0m"
                 color: "#ffffff"
                 font.pixelSize: 14
                 font.family: "Fira Sans Semibold"
@@ -228,6 +236,14 @@ Rectangle {
         }
     }
 
+    Timer {
+        id: uptimeTimer
+        interval: 60000
+        running: true
+        repeat: true
+        onTriggered: updateUptime()
+    }
+
     function updateVolume() {
         volumeSlider.value = Pipewire.defaultAudioSink.volume * 100
         if (Pipewire.defaultAudioSink.mute || volumeSlider.value === 0) {
@@ -248,6 +264,18 @@ Rectangle {
         } else {
             brightnessIcon.text = "\uf0eb"
         }
+    }
+
+    function updateUptime() {
+        var proc = Qt.createQmlObject('import Qt.labs.platform 1.1; Process {}', root);
+        proc.command = "cat";
+        proc.arguments = ["/proc/uptime"];
+        proc.start();
+        proc.waitForFinished();
+        var seconds = parseFloat(proc.readAllStandardOutput().split(" ")[0]);
+        var hours = Math.floor(seconds / 3600);
+        var minutes = Math.floor((seconds % 3600) / 60);
+        uptimeText.text = "Uptime: " + hours + "h, " + minutes + "m";
     }
 
     Connections {
@@ -275,6 +303,7 @@ Rectangle {
         var mx = parseInt(proc2.readAllStandardOutput());
         brightnessSlider.value = (cur / mx) * 100;
         updateBrightnessIcon();
+        updateUptime();
     }
 }
 


### PR DESCRIPTION
## Summary
- Close ConnectionSettings when pressing Escape
- Hide ConnectionSettings when clicking outside
- Display real system uptime in ConnectionSettings

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e68ba6a54832cbc028d2e4f0702d2