### PR TITLE
Make volume icon in ConnectionSettings open pavucontrol

### DIFF
--- a/modules/bar/widgets/ConnectionSettings.qml
+++ b/modules/bar/widgets/ConnectionSettings.qml
@@ -132,6 +132,12 @@ Rectangle {
                 font.pixelSize: 16
                 font.family: "CaskaydiaMono Nerd Font"
                 Layout.alignment: Qt.AlignVCenter
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: Hyprland.dispatch("exec pavucontrol")
+                }
             }
 
             Slider {


### PR DESCRIPTION
## Summary
- make the volume icon in ConnectionSettings clickable
- launch `pavucontrol` when the volume icon is clicked

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_688e738ebac8832c9d596c21908a2fc0