### PR TITLE
feat: add notification window with dnd toggle

### DIFF
--- a/modules/bar/Bar.qml
+++ b/modules/bar/Bar.qml
@@ -3,6 +3,7 @@ import QtQuick.Shapes
 import Quickshell
 import Quickshell.Hyprland
 import Quickshell.Services.Pipewire
+import Quickshell.Services.Notifications
 import Qt.labs.platform 1.1
 import "widgets/"
 import org.kde.layershell 1.0
@@ -47,6 +48,27 @@ Variants {
 
                 ConnectionSettings {
                     id: connectionContent
+                    anchors.fill: parent
+                }
+            }
+
+            PanelWindow {
+                id: notificationWindow
+                screen: delegateRoot.modelData
+                anchors {
+                    top: true
+                    right: true
+                }
+                margins {
+                    right: 16
+                }
+                width: 300
+                height: notificationContent.implicitHeight
+                visible: false
+                color: "transparent"
+
+                Notifications {
+                    id: notificationContent
                     anchors.fill: parent
                 }
             }
@@ -180,7 +202,7 @@ Variants {
                         MouseArea {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
-                            onClicked: Hyprland.dispatch("swaync-client -t -sw")
+                            onClicked: notificationWindow.visible = !notificationWindow.visible
                         }
 
                         Text {

--- a/modules/bar/widgets/Notifications.qml
+++ b/modules/bar/widgets/Notifications.qml
@@ -1,0 +1,82 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Quickshell.Services.Notifications
+
+Rectangle {
+    id: root
+    property int margin: 16
+    anchors.fill: parent
+    color: "#222222"
+    radius: 8
+    border.color: "#555555"
+    border.width: 1
+    implicitHeight: content.implicitHeight + margin * 2
+
+    ColumnLayout {
+        id: content
+        anchors.fill: parent
+        anchors.margins: root.margin
+        spacing: 16
+
+        Rectangle {
+            id: dndButton
+            Layout.fillWidth: true
+            height: 30
+            radius: 6
+            color: Notifications.doNotDisturb ? "#444444" : "#333333"
+            border.color: "#555555"
+
+            Text {
+                anchors.centerIn: parent
+                text: Notifications.doNotDisturb ? "Disable Do Not Disturb" : "Enable Do Not Disturb"
+                color: "#ffffff"
+                font.pixelSize: 14
+                font.family: "Fira Sans Semibold"
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: Notifications.doNotDisturb = !Notifications.doNotDisturb
+            }
+        }
+
+        ListView {
+            id: notificationList
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            model: Notifications.notifications
+            spacing: 8
+
+            delegate: Rectangle {
+                width: notificationList.width
+                radius: 6
+                color: "#333333"
+                border.color: "#555555"
+                implicitHeight: bodyText.paintedHeight + titleText.paintedHeight + 16
+
+                Column {
+                    anchors.fill: parent
+                    anchors.margins: 8
+                    spacing: 4
+
+                    Text {
+                        id: titleText
+                        text: model.summary
+                        color: "#ffffff"
+                        font.pixelSize: 14
+                        font.bold: true
+                    }
+
+                    Text {
+                        id: bodyText
+                        text: model.body
+                        color: "#dddddd"
+                        font.pixelSize: 12
+                        wrapMode: Text.Wrap
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add notification window that displays system notifications
- add Do Not Disturb toggle button and replace external command

## Testing
- `npm test` (fails: package.json missing)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cc80a6a6c832ca8dad85cc8849b25